### PR TITLE
Fixed DLL import problem on Windows

### DIFF
--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -9,12 +9,7 @@
 
 static const unsigned int numLevels = 9;
 
-// use absolute paths on windows (strange behaviour)
-#ifndef _WIN32
-	#define PATH "./"
-#else
-	#define PATH "C:/GalacticIrrweg/trunk/VSPROJ/Project1/Debug/"
-#endif
+#define PATH "./"
 
 // window properties
 static const int pixelSizeX = 16;


### PR DESCRIPTION
The absolute path code on windows was causing a problem with loading libgcc_s_sjlj-1.dll
